### PR TITLE
Fix/faster command execution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,7 @@ setup(
   author = 'Solo',                  
   author_email = 'support@solomotorcontrollers.com',      
   url = 'https://github.com/Solo-FL/SoloPy',   
-  download_url = 'https://github.com/Solo-FL/SoloPy/archive/refs/tags/v3.1.3.tar.gz',    
-  keywords = ['Solo Motor controllers', 'Solo', 'SoloPy'],   
+  keywords = ['Solo Motor controllers', 'Solo', 'SoloPy'],
   install_requires=[           
           'pyserial==3.5',
           'python-can==4.2.2',


### PR DESCRIPTION
- Change to a configurable backoff time between writing commands to serial and starting to read.
- Remove retries and leave that up to the user of the API.

